### PR TITLE
Fix Cleartext traffic not permitted

### DIFF
--- a/app/src/main/java/net/xblacky/animexstream/utils/constants/C.kt
+++ b/app/src/main/java/net/xblacky/animexstream/utils/constants/C.kt
@@ -11,7 +11,7 @@ class C {
         const val NO_INTERNET_CONNECTION = 1001
 
         //Base URLS
-        var BASE_URL = "https://www.gogoanime.movie"
+        var BASE_URL = "https://www1.gogoanime.movie"
         const val EPISODE_LOAD_URL = "https://ajax.gogocdn.net/ajax/load-list-episode"
         const val SEARCH_URL = "/search.html"
 


### PR DESCRIPTION
It looks like the base URL https://www.gogoanime.movie redirects to an HTTP site instead of HTTPS

Log
> HTTP FAILED: java.net.UnknownServiceException: CLEARTEXT communication to www1.gogoanime.movie not permitted by network security policy