### PR TITLE
Update gogoanime URLs

### DIFF
--- a/app/src/main/java/net/xblacky/animexstream/utils/constants/C.kt
+++ b/app/src/main/java/net/xblacky/animexstream/utils/constants/C.kt
@@ -11,7 +11,7 @@ class C {
         const val NO_INTERNET_CONNECTION = 1001
 
         //Base URLS
-        var BASE_URL = "https://www1.gogoanime.movie"
+        var BASE_URL = "https://www1.gogoanime.ai"
         const val EPISODE_LOAD_URL = "https://ajax.gogocdn.net/ajax/load-list-episode"
         const val SEARCH_URL = "/search.html"
 
@@ -53,8 +53,8 @@ class C {
 
         //Network Requests Header
         const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36"
-        const val ORIGIN = "https://www1.gogoanime.movie"
-        const val  REFERER = "https://www1.gogoanime.movie/"
+        const val ORIGIN = "https://www1.gogoanime.ai"
+        const val  REFERER = "https://www1.gogoanime.ai/"
 
         //Realm
         const val MAX_TIME_M3U8_URL = 2 * 60 * 60 *1000


### PR DESCRIPTION
ISPs are blocking gogoanime.movie URL now, gogoanime.ai is new the URL that we can use.